### PR TITLE
Coverage Updates

### DIFF
--- a/app/coverage.gradle
+++ b/app/coverage.gradle
@@ -44,7 +44,7 @@ task testCoverage(type: JacocoReport, dependsOn: ["test${buildVariant}UnitTest",
 
     reports {
         xml.enabled true
-        xml.destination "${buildDir}/reports/jacoco/testCoverage/coverage.xml"
+        xml.destination "${buildDir}/reports/jacoco/testCoverage/jacoco.xml"
     }
 }
 
@@ -70,7 +70,7 @@ task unitTestCoverage(type: JacocoReport, dependsOn: "test${buildVariant}UnitTes
 
     reports {
         xml.enabled true
-        xml.destination "${buildDir}/reports/jacoco/unitTestCoverage/coverage.xml"
+        xml.destination "${buildDir}/reports/jacoco/unitTestCoverage/jacoco.xml"
     }
 }
 
@@ -87,7 +87,7 @@ task instrumentationTestCoverage(type: JacocoReport, dependsOn: "spoon${buildVar
 
     reports {
         xml.enabled true
-        xml.destination "${buildDir}/reports/jacoco/instrumentationTestCoverage/coverage.xml"
+        xml.destination "${buildDir}/reports/jacoco/instrumentationTestCoverage/jacoco.xml"
     }
 }
 

--- a/app/coverage.gradle
+++ b/app/coverage.gradle
@@ -23,7 +23,7 @@ def coverageClassDirs = fileTree(
 )
 
 def unitTestCoverageData = "${buildDir}/jacoco/test${buildVariant}UnitTest.exec"
-def instrumentationTestCoverageData = "${buildDir}/spoon/${buildVariantDirectory}/coverage/merged-coverage.ec"
+def instrumentationTestCoverageData = "${buildDir}/spoon-output/${buildVariantDirectory}/coverage/merged-coverage.ec"
 
 // testCoverageEnabled messes up debugging/etc, so we want it disabled most of times.
 // unit test coverage reports seems to work fine even with the flag disabled, but the

--- a/app/coverage.gradle
+++ b/app/coverage.gradle
@@ -54,9 +54,11 @@ task unitTestCoverage(type: JacocoReport, dependsOn: "test${buildVariant}UnitTes
     sourceDirectories = coverageSourceDirs
     classDirectories = fileTree(
             dir: "${buildDir}/intermediates/classes/${buildVariantDirectory}",
-            includes: ['**/*Presenter*',
-                       '**/utils/*'
-                       // Add any additional testable classes here
+            excludes: [*coverageClassDirs.excludes.asList(),
+                       '**/*Activity.class',
+                       '**/*Fragment.class',
+                       '**/*Service.class',
+                       '**/*Application.class'
             ]
     )
     executionData = files("${buildDir}/jacoco/test${buildVariant}UnitTest.exec")

--- a/app/coverage.gradle
+++ b/app/coverage.gradle
@@ -12,7 +12,7 @@ def buildVariantDirectory = "${productFlavor}/${buildType}"
 
 def coverageSourceDirs = files(['src/main/kotlin'])
 def coverageClassDirs = fileTree(
-        dir: "${buildDir}/intermediates/classes/${buildVariantDirectory}",
+        dir: "${buildDir}/tmp/kotlin-classes/${buildVariantDirectory}",
         excludes: ['**/R.class',
                    '**/R$*.class',
                    '**/BuildConfig.*',
@@ -53,7 +53,7 @@ task testCoverage(type: JacocoReport, dependsOn: ["test${buildVariant}UnitTest",
 task unitTestCoverage(type: JacocoReport, dependsOn: "test${buildVariant}UnitTest") {
     sourceDirectories = coverageSourceDirs
     classDirectories = fileTree(
-            dir: "${buildDir}/intermediates/classes/${buildVariantDirectory}",
+            dir: "${buildDir}/tmp/kotlin-classes/${buildVariantDirectory}",
             excludes: [*coverageClassDirs.excludes.asList(),
                        '**/*Activity.class',
                        '**/*Fragment.class',

--- a/build.gradle
+++ b/build.gradle
@@ -8,11 +8,13 @@ buildscript {
         jcenter()
         maven { url 'https://maven.fabric.io/public' }
         maven { url "https://plugins.gradle.org/m2/" }
+        maven { url "https://oss.sonatype.org/content/repositories/snapshots" } // TODO remove this once spoon 2.0.0 is stable
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.stanfy.spoon:spoon-gradle-plugin:1.2.2'
+        classpath "com.jaredsburrows:gradle-spoon-plugin:1.3.0"
+        classpath "com.squareup.spoon:spoon-runner:2.0.0-SNAPSHOT" // TODO update/remove this once spoon 2.0.0 is stable
         classpath 'io.fabric.tools:gradle:1.25.1'
         classpath "gradle.plugin.io.intrepid:static-analysis:1.0.3"
     }


### PR DESCRIPTION
This does the same stuff as [Skeleton #53](https://github.com/IntrepidPursuits/skeleton-android/pull/53). 

Additionally, it corrects the folder from which we read kotlin-generated class files. We've been generating empty jacoco reports, and I'm actually really unclear on why that hasn't been reflected on Jenkins, but in any case this should correct it.